### PR TITLE
change to replace copyOfRange usage

### DIFF
--- a/src/com/amvdce/algo001/TableSeating.java
+++ b/src/com/amvdce/algo001/TableSeating.java
@@ -72,10 +72,18 @@ public class TableSeating {
 	 */
 	protected boolean canSit(boolean[] tables, int pos, int tabPerCust) {
 		if (pos + tabPerCust > tables.length) return false;
-		boolean[] tableSub = Arrays.copyOfRange(tables, pos, pos+tabPerCust);
-		if (countFalse(tableSub) < tableSub.length) return false;
+		for (int i = pos; i < pos+tabPerCust; i++) {
+			if (tables[i]) return false;
+		}
 		return true;		
 	}
+	
+//	protected boolean canSit(boolean[] tables, int pos, int tabPerCust) {
+//		if (pos + tabPerCust > tables.length) return false;
+//		boolean[] tableSub = Arrays.copyOfRange(tables, pos, pos+tabPerCust);
+//		if (countFalse(tableSub) < tableSub.length) return false;
+//		return true;		
+//	}
 	
 	
 	/**

--- a/src/com/amvdce/algo001/TestTableSeating.java
+++ b/src/com/amvdce/algo001/TestTableSeating.java
@@ -32,10 +32,13 @@ public class TestTableSeating extends TestCase {
 	
 	public void testCanSit() {
 		TableSeating tS = new TableSeating();
-		boolean [] tables = new boolean[]{true, true, false, false, false};
-		int pos = 2;
+		boolean [] tables = new boolean[]{false, false, true, false, false, false, true, true, false, false, false, false};
+		int pos = 3;
 		int tabPerCust = 3;
-		assertTrue(tS.canSit(tables, pos, tabPerCust));
+		for (int i = 0; i < 3000; i++) {
+			pos = i%11;
+			assertTrue(tS.canSit(tables, pos, tabPerCust));
+		}
 	}
 	
 	public void testSitCust() {


### PR DESCRIPTION
JProfiler suggested that Arrays.copyOfRange is suboptimal (few calls but a huge time chunk), I reviewed and removed the unnecessary complexity in "canSit", and cut the usage of the said lib method. I am still measuring if it makes a diff. 
